### PR TITLE
fix(theme): opt out of catppuccin.cursors to resolve pointerCursor co…

### DIFF
--- a/modules/home/desktop/common/theme.nix
+++ b/modules/home/desktop/common/theme.nix
@@ -14,6 +14,10 @@
     # manual mocha palette in wm/hyprland; module injects a broken
     # lua-inline `colors` block into hyprlang (upstream bug)
     hyprland.enable = false;
+    # cursor is phinger-cursors-light (set via home.pointerCursor below and
+    # niri cursor.theme); catppuccin.cursors sets a conflicting
+    # home.pointerCursor.name at normal priority -> eval conflict (issue #26)
+    cursors.enable = false;
   };
 
   home.pointerCursor = {

--- a/modules/nixos/nix.nix
+++ b/modules/nixos/nix.nix
@@ -44,6 +44,10 @@
     allowUnfree = true;
     permittedInsecurePackages = [
       "ventoy-1.1.12" # unfixed upstream CVEs; still a handy USB utility
+      # pnpm-10.29.2 is marked insecure in nixpkgs. Keep the permit until
+      # `nix why-depends` confirms pnpm left the closure (vesktop, its
+      # consumer, was dropped in 67a0d93). A permit matching nothing is a no-op.
+      "pnpm-10.29.2"
     ];
   };
 }


### PR DESCRIPTION
…nflict

The 2026-07-09 nightly bump (issue #26) failed eval with a conflicting `home.pointerCursor.name`: theme.nix sets "phinger-cursors-light" while catppuccin's cursors module sets "catppuccin-mocha-lavender-cursors", both at normal priority.

catppuccin.cursors has been active all along via `autoEnable = true` and sets home.pointerCursor.name at normal priority without gating on home.pointerCursor.enable. The conflict was latent while home.pointerCursor.enable was false (home-manager never forced .name). Commit 6dbdda5 set enable = true (per scan #25), which forces .name and surfaces the conflict. The config deliberately wants phinger-cursors (theme.nix package/name + niri cursor.theme), so opt out of catppuccin's cursor module, matching the existing firefox/hyprland opt-out pattern.

Also restore the pnpm-10.29.2 insecure permit that 6dbdda5 removed: pnpm-10.29.2 is marked insecure in nixpkgs, and the removal was not build-confirmed (the 07-09 build failed on the cursor conflict before the insecure check ran). A permit matching nothing is a no-op, so keeping it is safe until `nix why-depends` confirms pnpm has left the closure.


Claude-Session: https://claude.ai/code/session_01XNKxjerpUpeScrDPTS4ufw